### PR TITLE
Close files explicitly

### DIFF
--- a/libwapiti/src/api.c
+++ b/libwapiti/src/api.c
@@ -116,6 +116,7 @@ mdl_t *api_load_model(char *filename, opt_t *options) {
   if (file == NULL)
     pfatal("cannot open input model file: %s", filename);
   mdl_load(mdl, file);
+  fclose(file);
   return mdl;
 }
 

--- a/wapiti.py
+++ b/wapiti.py
@@ -244,7 +244,8 @@ class Model:
             )
         else:
             if self.options.pattern:
-                self.patterns = open(self.options.pattern).read()
+                with open(self.options.pattern) as fp:
+                    self.patterns = fp.read()
             else:
                 self.patterns = patterns
 
@@ -271,10 +272,14 @@ class Model:
 
 
     def save(self, modelfile):
-        if type(modelfile) != file:
-            modelfile = open(modelfile, 'w')
-        fp = ctypes.pythonapi.PyFile_AsFile(modelfile)
-        _wapiti.api_save_model(self._model, fp)
+        if isinstance(modelfile, file):
+            fp = ctypes.pythonapi.PyFile_AsFile(modelfile)
+            _wapiti.api_save_model(self._model, fp)
+        else:
+            with open(modelfile, 'w') as py_f:
+                fp = ctypes.pythonapi.PyFile_AsFile(py_f)
+                _wapiti.api_save_model(self._model, fp)
+
 
     def label_sequence(self, lines, include_input=False):
         """


### PR DESCRIPTION
This should prevent "OSError: Too many open files" errors. I actually got this error after creating many models.
