### PR TITLE
Fix "out of memory" errors

### DIFF
--- a/libwapiti/src/api.c
+++ b/libwapiti/src/api.c
@@ -137,6 +137,14 @@ char *api_label_seq(mdl_t *mdl, char *lines, bool input) {
 	seq_t *seq = rdr_raw2seq(mdl->reader, raw, mdl->opt->check);
 	const int T = seq->len;
 
+    // When empty sequence is passed, return an empty string as response:
+    // subsequent mallocs will fail otherwise because of zero T.
+	if (!T) {
+	  rdr_freeraw(raw);
+	  rdr_freeseq(seq);
+	  return xstrdup("");
+	}
+
 	uint32_t *out = xmalloc(sizeof(uint32_t) * T);
 	double *psc = xmalloc(sizeof(double) * T);
 	double *scs = xmalloc(sizeof(double));


### PR DESCRIPTION
Such errors happen when empty lines are passed to Model.label_sequence.
Model.label_sequence now returns empty string when "lines" argument is empty.
