### PR TITLE
rename wapiti.py to pywapiti

### DIFF
--- a/scripts/pywapiti
+++ b/scripts/pywapiti
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from wapiti.script import run_script
 
 if __name__ == '__main__':
+    from wapiti.script import run_script
     run_script()

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(name='libwapiti',
               extra_link_args=['-lm', '-lpthread'],
           )
       ],
-      scripts=['scripts/wapiti.py',],
+      scripts=['scripts/pywapiti',],
       install_requires=['six',],
 )


### PR DESCRIPTION
Hey @adsva,

I broke things in https://github.com/adsva/python-wapiti/pull/8 - wapiti.py was a very bad name because it shadows / is shadowed by wapiti package in some circumstances.
