### PR TITLE
Broken string when calling wapiti.api.Model.label_sequence

### DIFF
--- a/libwapiti/src/api.c
+++ b/libwapiti/src/api.c
@@ -25,10 +25,13 @@ static raw_t *api_str2raw(char *seq) {
   int size = 32; // Initial number of lines in raw_t
   int cnt = 0;
   char *line;
+  const unsigned int L = strlen(seq)+1;
+  char *tmp_seq = (char*) malloc(sizeof(char) * L);
+  strncpy(tmp_seq, seq, L);
 
   raw_t *raw = xmalloc(sizeof(raw_t) + sizeof(char *) * size);
 
-  for (line = strtok(seq, "\n") ; line ; line = strtok(NULL, "\n")) {
+  for (line = strtok(tmp_seq, "\n") ; line ; line = strtok(NULL, "\n")) {
     // Make sure there's room and add the line
     if (cnt == size) {
       size *= 1.4;
@@ -38,6 +41,7 @@ static raw_t *api_str2raw(char *seq) {
   }
   raw = xrealloc(raw, sizeof(raw_t) + sizeof(char *) * cnt);
   raw->len = cnt;
+  free(tmp_seq);
   return raw;
 }
 

--- a/libwapiti/src/api.c
+++ b/libwapiti/src/api.c
@@ -25,9 +25,7 @@ static raw_t *api_str2raw(char *seq) {
   int size = 32; // Initial number of lines in raw_t
   int cnt = 0;
   char *line;
-  const unsigned int L = strlen(seq)+1;
-  char *tmp_seq = (char*) malloc(sizeof(char) * L);
-  strncpy(tmp_seq, seq, L);
+  char *tmp_seq = xstrdup(seq);
 
   raw_t *raw = xmalloc(sizeof(raw_t) + sizeof(char *) * size);
 


### PR DESCRIPTION
When calling the method wapiti.api.Model.label_sequence, the python string get silently broken.

```python2
import wapiti.api

model = wapiti.api.Model([...])
seq = "some\ninput\nsequence"

print seq
print "="*10
print model.label_sequence(seq)
print "="*10
print model.label_sequence(seq)
print "="*10
print seq
```

The problem is in the function api_str2raw called by api_label_seq in api.c which modifies the input string by calling strtok.

Proposed fix: a copy of seq is created at the beginning of api_str2raw to avoid modifying the input string.